### PR TITLE
fix(index): Remove angular4

### DIFF
--- a/index.md
+++ b/index.md
@@ -54,7 +54,6 @@ We will implement the [same wireframes](https://www.drupal.org/node/2818741#comm
 | Front-end | Status       | Example | Code   |
 |:----------|:-------------|:--------|:-------|
 | Angular   | Running demo | [Website](https://contenta-angular.firebaseapp.com/) | [Repo](https://github.com/contentacms/contenta_angular) |
-| Angular 4 | Planned      | Not yet | Not yet |
 | Elm       | Running demo | [Website](https://contenta-elm.firebaseapp.com/) | [Repo](https://github.com/contentacms/contenta_jsonapi__elm) |
 | Ember     | Need help    | Not yet | [Repo](https://github.com/contentacms/contenta_ember) |
 | Ionic     | Running demo | Not yet | [Repo](https://github.com/contentacms/contenta_ionic) |


### PR DESCRIPTION
Remove angular4 from frontends list. There should be no Angular4. There is only one "Angular". This might have been some confusion on the chat. But there is only one version of "Angular" which is currently on version 4 but thats only a semver number..(and the current angular we have is on version 4 already and will be updated everytime a new release is launched)

The other Angular that exists is the previous version of Angular (mostly known as Angular1) but should always be refered as "AngularJs".