### PR TITLE
Fix sentences order in "quick installation"

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,15 +12,14 @@ Read more about Contenta's mission in [this blog post](https://medium.com/@mateu
   <iframe height="315" src="https://www.youtube.com/embed/MOQ0gd7uEWU" frameborder="0" allowfullscreen="" width="560"></iframe>
 </p>
 
+The quick installation is intended for **local development** only.
+For this to work you will need to have composer installed in your local machine. See [get composer](https://getcomposer.org/) for more details. Also, make sure that the sqlite-extension is installed (`sudo apt-get install php-sqlite3` in debian/ubuntu).
+
 ```bash
 php -r "readfile('https://raw.githubusercontent.com/contentacms/contenta_jsonapi/8.x-1.x/installer.sh');" > contentacms.sh
 chmod a+x contentacms.sh
 ./contentacms.sh
 ```
-
-For this to work you will need to have composer installed in your local machine. See [get composer](https://getcomposer.org/) for more details. Also, make sure that the sqlite-extension is installed (`sudo apt-get install php-sqlite3` in debian/ubuntu).
-
-The quick installation is intended for **local development** only.
 
 ## [](#goals)Goals
 One of the conclusions of DrupalCon Baltimore was that Drupal 8 has **impressive tools to build a decoupled application**. However, assembling all the tools together and setting them up correctly can be a little bit daunting. On top of that, once you have everything set up you need to figure out the ins and outs of your front-end project.


### PR DESCRIPTION
Installing contenta this morning, i used quick install and understood that this is only for demo purposes to test quickly contenta, right ? But feels like sentences are not in the right order to catch it, so i suggest saying first "this is for local development only", then adding "requirements" for this to work and lastly the command line.