### PR TITLE
fix(vuejs): Change url for Vue / Nuxt demo site

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@ composer create-project contentacms/contenta-jsonapi-project MYPROJECT --stabili
             <tr>
               <td>Vue.js + Nuxt.js</td>
               <td>In progress</td>
-              <td><a href="https://contentavuenuxt.github.io/">Website</a></td>
+              <td><a href="https://contentanuxt.now.sh/">Website</a></td>
               <td><a href="https://github.com/contentacms/contenta_vue_nuxt">Repo</a></td>
             </tr>
             <tr>


### PR DESCRIPTION
The Vue / Nuxt demo site can not be hosted into github pages (https://contentavuenuxt.github.io/) because nuxt is designed to be served from a node js server.

The new demo site has been deployed to the new url : https://contentanuxt.now.sh/